### PR TITLE
Bugfix/header close menu button

### DIFF
--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -16,11 +16,11 @@
             </button>
 
             <!--Mobile menu close button-->
-            <div class="menu-close js-close-menu">
+            <button class="menu-close js-close-menu">
               <svg width="36" height="36">
                 <use href="./icons/sprite.svg#cross-icon"></use>
               </svg>
-            </div>
+            </button>
           </div>
 
           <ul class="list header-nav">

--- a/src/sass/layout/_header.scss
+++ b/src/sass/layout/_header.scss
@@ -101,6 +101,8 @@
   svg {
     fill: #86e543;
   }
+
+  cursor: pointer;
 }
 
 .menu-close {
@@ -108,13 +110,19 @@
   top: 0;
   right: 0;
 
+  width: 36px;
+  height: 36px;
+  padding: 0;
+
+  background-color: transparent;
+  border: none;
+  outline: none;
+
   @media screen and (min-width: 768px) {
     left: 0;
   }
 
-  width: 36px;
-  height: 36px;
-
+  cursor: pointer;
   opacity: 0;
   transition: opacity;
 }

--- a/src/sass/layout/_header.scss
+++ b/src/sass/layout/_header.scss
@@ -20,7 +20,6 @@
 .pageheader {
   position: absolute;
   display: flex;
-  // justify-content: space-between;
   align-items: center;
 
   @media screen and (max-width: 479px) {
@@ -55,7 +54,12 @@
 .logo {
   display: block;
   width: 115px;
+  @media screen and (min-width: 768px) {
+    width: 156px;
+    margin-right: 161px;
+  }
   @media screen and (min-width: 1280px) {
+    width: 121px;
     margin-right: 343px;
   }
 
@@ -71,6 +75,12 @@
 .menu-btn {
   position: relative;
   display: flex;
+  margin-left: auto;
+  @media screen and (min-width: 768px) {
+    margin-left: 0;
+    margin-right: auto;
+  }
+
   @media screen and (min-width: 1280px) {
     display: none;
   }
@@ -112,7 +122,7 @@
 .header-nav {
   display: flex;
   gap: 48px;
-  margin-right: 362px;
+  margin-right: auto;
   @media screen and (max-width: 1279px) {
     display: none;
   }

--- a/src/sass/layout/_header.scss
+++ b/src/sass/layout/_header.scss
@@ -20,7 +20,7 @@
 .pageheader {
   position: absolute;
   display: flex;
-  justify-content: space-between;
+  // justify-content: space-between;
   align-items: center;
 
   @media screen and (max-width: 479px) {
@@ -55,6 +55,10 @@
 .logo {
   display: block;
   width: 115px;
+  @media screen and (min-width: 1280px) {
+    margin-right: 343px;
+  }
+
   font-weight: 700;
   font-size: 24px;
   line-height: 1.17;
@@ -94,6 +98,10 @@
   top: 0;
   right: 0;
 
+  @media screen and (min-width: 768px) {
+    left: 0;
+  }
+
   width: 36px;
   height: 36px;
 
@@ -104,6 +112,7 @@
 .header-nav {
   display: flex;
   gap: 48px;
+  margin-right: 362px;
   @media screen and (max-width: 1279px) {
     display: none;
   }


### PR DESCRIPTION
исправил 
1.расположение кнопки-крестика по отношению к бургеру - в таблетке он должен быть по левый край бургера, а в мобильном меню по правую сторону от бургера
2.исправил ширину Лого для таблетки (156рх) и десктопа (121рх)
3.исправил маржинами расстояния между Лого, навигацией и правой кнопкой в таблетке и десктопе